### PR TITLE
Clear tmp/cache before build

### DIFF
--- a/lib/middleman/fragment_caching/extension.rb
+++ b/lib/middleman/fragment_caching/extension.rb
@@ -6,7 +6,7 @@ module Middleman
         Cache.instance.clear!
       end
 
-      def before_build
+      def before_build(_)
         FileUtils.rm_rf('tmp/cache')
       end
 

--- a/lib/middleman/fragment_caching/extension.rb
+++ b/lib/middleman/fragment_caching/extension.rb
@@ -1,8 +1,13 @@
 module Middleman
   module FragmentCaching
     class Extension < ::Middleman::Extension
+
       def after_build(_)
         Cache.instance.clear!
+      end
+
+      def before_build
+        FileUtils.rm_rf('tmp/cache')
       end
 
       helpers do


### PR DESCRIPTION
The issue I encountered is once the tmp cache files have been created they don't expire; changes to the contents wrapped inside the `fragment_cache` do not expire the cache.

The before_build call back clears the tmp/cache to ensure up-to-date fragments are generated
